### PR TITLE
feat: add coin contents on summary view

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -102,7 +102,6 @@ setting 관련
 /* Summary box */
 .summary-grid {
     height: 380px;
-    display: flex;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     border-radius: 8px; 
     background-color: #ffffff;

--- a/assets/summary.css
+++ b/assets/summary.css
@@ -1,0 +1,37 @@
+/* 코인 */
+
+.coin-summary-view {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center; /* 텍스트 중앙 정렬 */
+    padding: 10px 0;
+}
+
+.coin-divide-line {
+    width: 100%; /* 구분선의 너비를 조정 */
+    margin: 30px 0; /* 구분선 위아래 여백 */
+    color: lightgray;
+    border: 1px solid lightgray;
+    
+}
+
+.coin-position {
+    display: flex;
+    justify-content: space-between; /* 왼쪽과 오른쪽으로 정렬 */
+    width: 100%; /* 전체 너비 사용 */
+}
+
+.coin-left-text {
+    margin-left: 30px; /* 기본 여백 제거 */
+    font-size: 18px;
+    font-weight: 800;
+}
+
+.coin-right-text {
+    margin-right: 30px; /* 기본 여백 제거 */
+    text-align: right; /* 오른쪽 정렬 */
+    font-size: 18px;
+    font-weight: 600;
+}

--- a/callbacks.py
+++ b/callbacks.py
@@ -1,3 +1,36 @@
-from dash import Input, Output
+from dash import Input, Output, callback
 import plotly.express as px
 import pandas as pd
+import requests
+
+
+# 코인 시세 콜백 함수
+krw_usd_flag = 0
+
+@callback(
+    Output('price-bitcoin', 'children'), 
+    Output('price-ethereum', 'children'), 
+    Output('price-xrp', 'children'),
+    Input('interval-component-bit', 'n_intervals'), 
+    Input('interval-component-eth', 'n_intervals'), 
+    Input('interval-component-xrp', 'n_intervals')
+)
+def update_price(a, b, c):
+    global krw_usd_flag
+    url = "https://api.upbit.com/v1/ticker"
+    market_type = "USDT" if krw_usd_flag % 2 == 1 else "KRW"
+    querystring = {"markets": f"{market_type}-BTC,{market_type}-ETH,{market_type}-XRP"}
+
+    response = requests.get(url, params=querystring)
+    data = response.json()
+
+    bit_price = data[0]['trade_price']
+    eth_price = data[1]['trade_price']
+    xrp_price = data[2]['trade_price']
+    krw_usd_flag += 1
+
+    return (
+        f'{bit_price:,} {market_type}',
+        f'{eth_price:,} {market_type}',
+        f'{xrp_price:,} {market_type}'
+    )

--- a/callbacks.py
+++ b/callbacks.py
@@ -24,13 +24,19 @@ def update_price(a, b, c):
     response = requests.get(url, params=querystring)
     data = response.json()
 
-    bit_price = data[0]['trade_price']
-    eth_price = data[1]['trade_price']
-    xrp_price = data[2]['trade_price']
+    # 시세 정보와 변동 정보 추출
+    prices_changes = [(coin['trade_price'], update_change(coin['change'])) for coin in data]
+
     krw_usd_flag += 1
 
-    return (
-        f'{bit_price:,} {market_type}',
-        f'{eth_price:,} {market_type}',
-        f'{xrp_price:,} {market_type}'
+    return tuple(
+        f'{price:,} {market_type} {change}' for price, change in prices_changes
     )
+
+def update_change(change):
+    change_symbols = {
+        'RISE': '▲',
+        'FALL': '▼'
+    }
+    return change_symbols.get(change, 'ᐉ')
+        

--- a/components/coin.py
+++ b/components/coin.py
@@ -1,0 +1,25 @@
+from dash import html, dcc
+
+def coin_summary_view():
+    coins = [
+        ('비트코인 BTC', 'price-bitcoin'),
+        ('이더리움 ETH', 'price-ethereum'),
+        ('리플 XRP', 'price-xrp')
+    ]
+
+    intervals = 5*1000  # 5초
+    coin_divs = []
+    for name, price_id in coins:
+        coin_divs.append(html.Div([
+            html.P(name, className='coin-left-text'),
+            html.P(f'{name.split()[0]} 가격', className='coin-right-text', id=price_id)
+        ], className='coin-position'))
+        coin_divs.append(html.Hr(className="coin-divide-line"))
+
+    intervals = [
+        dcc.Interval(id='interval-component-bit', interval=intervals, n_intervals=0),
+        dcc.Interval(id='interval-component-eth', interval=intervals, n_intervals=0),
+        dcc.Interval(id='interval-component-xrp', interval=intervals, n_intervals=0)
+    ]
+
+    return html.Div(coin_divs + intervals, className="coin-summary-view")

--- a/components/coin.py
+++ b/components/coin.py
@@ -15,6 +15,7 @@ def coin_summary_view():
             html.P(f'{name.split()[0]} 가격', className='coin-right-text', id=price_id)
         ], className='coin-position'))
         coin_divs.append(html.Hr(className="coin-divide-line"))
+    coin_divs.pop()
 
     intervals = [
         dcc.Interval(id='interval-component-bit', interval=intervals, n_intervals=0),

--- a/components/interest_summarize.py
+++ b/components/interest_summarize.py
@@ -1,6 +1,7 @@
 import dash_mantine_components as dmc
-from dash import html
-
+from dash import html, dcc, callback, Input, Output
+import requests
+    
 def render_music():
     return dmc.Container(
         dmc.Stack(
@@ -12,9 +13,73 @@ def render_music():
         className="summary-grid"
     )
 
+def coin_summary_view():
+    return html.Div([
+        html.Div([
+            html.P('비트코인 BTC', className='coin-left-text'),
+            html.P(f'비트코인 가격', className='coin-right-text', id='price-bitcoin')
+        ], className='coin-position'),
+        html.Hr(className="coin-divide-line"),
+        html.Div([
+            html.P('이더리움 ETH', className='coin-left-text'),
+            html.P('이더리움 가격', className='coin-right-text', id='price-ethereum')
+        ], className='coin-position'),
+        html.Hr(className="coin-divide-line"),
+        html.Div([
+            html.P('리플 XRP', className='coin-left-text'),
+            html.P('리플 가격', className='coin-right-text', id='price-xrp')
+        ], className='coin-position'),
+        
+        dcc.Interval(
+            id='interval-component-bit',
+            interval=3*1000,  # 5초
+            n_intervals=0
+        ),
+        dcc.Interval(
+            id='interval-component-eth',
+            interval=3*1000,  # 5초
+            n_intervals=0
+        ),
+        dcc.Interval(
+            id='interval-component-xrp',
+            interval=3*1000,  # 5초
+            n_intervals=0
+        ),
+    ], className="coin-summary-view")
+
+@callback(
+    Output('price-bitcoin', 'children'), 
+    Output('price-ethereum', 'children'), 
+    Output('price-xrp', 'children'),
+    Input('interval-component-bit', 'n_intervals'), 
+    Input('interval-component-eth', 'n_intervals'), 
+    Input('interval-component-xrp', 'n_intervals')
+)
+def update_price(a, b, c):
+    krw_usd_flag = 0
+    url = "https://api.upbit.com/v1/ticker"
+    if krw_usd_flag % 2 == 1:
+        querystring = {"markets": "USDT-BTC,USDT-ETH,USDT-XRP"}
+    else:
+        querystring = {"markets": "KRW-BTC,KRW-ETH,KRW-XRP"}
+
+    # API 호출
+    response = requests.get(url, params=querystring)
+    data = response.json()
+
+    # 시세 정보 추출
+    bit_price = data[0]['trade_price']
+    eth_price = data[1]['trade_price']
+    xrp_price = data[2]['trade_price']
+    krw_usd_flag += 1
+    return f'{bit_price:,} USDT', f'{eth_price:,} USDT', f'{xrp_price:,} USDT'
+    
+
+
+
 def render_coin():
     return dmc.Container(
-        dmc.GridCol("Coin summary", ta="center"),
+        dmc.GridCol(coin_summary_view(), ta="center"),
         className="summary-grid"
     )
 

--- a/components/interest_summarize.py
+++ b/components/interest_summarize.py
@@ -1,7 +1,7 @@
 import dash_mantine_components as dmc
 from dash import html, dcc, callback, Input, Output
-import requests
-    
+from .coin import coin_summary_view
+
 def render_music():
     return dmc.Container(
         dmc.Stack(
@@ -12,70 +12,6 @@ def render_music():
         ),
         className="summary-grid"
     )
-
-def coin_summary_view():
-    return html.Div([
-        html.Div([
-            html.P('비트코인 BTC', className='coin-left-text'),
-            html.P(f'비트코인 가격', className='coin-right-text', id='price-bitcoin')
-        ], className='coin-position'),
-        html.Hr(className="coin-divide-line"),
-        html.Div([
-            html.P('이더리움 ETH', className='coin-left-text'),
-            html.P('이더리움 가격', className='coin-right-text', id='price-ethereum')
-        ], className='coin-position'),
-        html.Hr(className="coin-divide-line"),
-        html.Div([
-            html.P('리플 XRP', className='coin-left-text'),
-            html.P('리플 가격', className='coin-right-text', id='price-xrp')
-        ], className='coin-position'),
-        
-        dcc.Interval(
-            id='interval-component-bit',
-            interval=3*1000,  # 5초
-            n_intervals=0
-        ),
-        dcc.Interval(
-            id='interval-component-eth',
-            interval=3*1000,  # 5초
-            n_intervals=0
-        ),
-        dcc.Interval(
-            id='interval-component-xrp',
-            interval=3*1000,  # 5초
-            n_intervals=0
-        ),
-    ], className="coin-summary-view")
-
-@callback(
-    Output('price-bitcoin', 'children'), 
-    Output('price-ethereum', 'children'), 
-    Output('price-xrp', 'children'),
-    Input('interval-component-bit', 'n_intervals'), 
-    Input('interval-component-eth', 'n_intervals'), 
-    Input('interval-component-xrp', 'n_intervals')
-)
-def update_price(a, b, c):
-    krw_usd_flag = 0
-    url = "https://api.upbit.com/v1/ticker"
-    if krw_usd_flag % 2 == 1:
-        querystring = {"markets": "USDT-BTC,USDT-ETH,USDT-XRP"}
-    else:
-        querystring = {"markets": "KRW-BTC,KRW-ETH,KRW-XRP"}
-
-    # API 호출
-    response = requests.get(url, params=querystring)
-    data = response.json()
-
-    # 시세 정보 추출
-    bit_price = data[0]['trade_price']
-    eth_price = data[1]['trade_price']
-    xrp_price = data[2]['trade_price']
-    krw_usd_flag += 1
-    return f'{bit_price:,} USDT', f'{eth_price:,} USDT', f'{xrp_price:,} USDT'
-    
-
-
 
 def render_coin():
     return dmc.Container(


### PR DESCRIPTION
- 비트코인, 이더리움, 리플 시세 추가
- 5초마다 가격 갱신 및 화폐 단위 변경 (KRW/USDT)
- 증감세에 따라 화살표 이모지 갱신(상승/보합/하락)